### PR TITLE
Speed up ZTF schema reclassification

### DIFF
--- a/src/groovy/com/astrolabsoftware/FinkBrowser/Januser/FinkGremlinRecipiesGT.groovy
+++ b/src/groovy/com/astrolabsoftware/FinkBrowser/Januser/FinkGremlinRecipiesGT.groovy
@@ -481,17 +481,50 @@ public trait FinkGremlinRecipiesGT extends GremlinRecipiesGT {
                                                  double  nmax  = 10,
                                                  boolean check = true) {                        
     def classified = classification(oid, srcClassifier);
-    def reclassified = [:];      
-    def w;
+    def reclassified = [:];
     def cf = classifierWithFlavor(srcClassifier);
-    classified.each {it -> if (it.classifier == cf[0] && it.flavor == cf[1]) {
-                             w = reclassify(it.class, 'OCol', srcClassifier, dstClassifier);
-                             w.each {cls, intersection -> if (reclassified[cls] == null) {
-                                                            reclassified[cls] = 0;
-                                                            }
-                                                          reclassified[cls] += intersection * it.weight;
-                               }
-                      }
+    def srcClasses = classified.findAll {it -> it.classifier == cf[0] && it.flavor == cf[1]}.
+                                collect {it -> it.class}.
+                                toSet();
+    def dstCf = classifierWithFlavor(dstClassifier);
+    def correlations = [:];
+    if (!srcClasses.isEmpty()) {
+      g().V().has('lbl',        'OCol').
+              has('classifier', cf[0]).
+              has('flavor',     cf[1]).
+              has('cls',        within(srcClasses)).
+              inE().has('lbl', 'overlaps').
+              as('e').
+              filter(outV().has('lbl',        'OCol').
+                            has('classifier', dstCf[0]).
+                            has('flavor',     dstCf[1])).
+              project('src', 'dst', 'intersection').
+              by(inV().values('cls')).
+              by(outV().values('cls')).
+              by(select('e').values('intersection')).
+              each {row ->
+                if (correlations[row['src']] == null) {
+                  correlations[row['src']] = [:];
+                  }
+                def previous = correlations[row['src']][row['dst']];
+                if (previous == null || row['intersection'] > previous) {
+                  correlations[row['src']][row['dst']] = row['intersection'];
+                  }
+                };
+      correlations.each {src, weights -> correlations[src] = weights.sort{-it.value}};
+      }
+    classified.each {it ->
+      if (it.classifier == cf[0] && it.flavor == cf[1]) {
+        def weights = correlations[it.class];
+        if (weights != null) {
+          weights.each {cls, intersection ->
+            if (reclassified[cls] == null) {
+              reclassified[cls] = 0;
+              }
+            reclassified[cls] += intersection * it.weight;
+            }
+          }
+        }
       }
     double total = reclassified.values().sum();
     if (total != 0) {
@@ -500,6 +533,7 @@ public trait FinkGremlinRecipiesGT extends GremlinRecipiesGT {
     if (check) {
       def classifiedDst = classification(oid, dstClassifier);
       if (classifiedDst.isEmpty()) {
+        _lastQuality = 0.0
         log.warn('Cannot check quality')
         }
       else {
@@ -515,11 +549,10 @@ public trait FinkGremlinRecipiesGT extends GremlinRecipiesGT {
       }
     reclassified = limitMap(reclassified, nmax);
     def reclassifiedA = [];
-    reclassified.each {it -> cf = classifierWithFlavor(dstClassifier);
-                             reclassifiedA += ['classifier':cf[0],
-                                               'flavor':cf[1],
-                                               'weight':it.getValue(),
-                                               'class':it.getKey()]}
+    reclassified.each {it -> reclassifiedA += ['classifier':dstCf[0],
+                                                'flavor':dstCf[1],
+                                                'weight':it.getValue(),
+                                                'class':it.getKey()]}
     return reclassifiedA;
     } 
     
@@ -854,34 +887,30 @@ public trait FinkGremlinRecipiesGT extends GremlinRecipiesGT {
                                      String srcClassifier,
                                      String dstClassifier) {
     def classification = [:];
+    if (cls == null || lbl == null || srcClassifier == null || dstClassifier == null) {
+      return classification;
+      }
     def srcCf = classifierWithFlavor(srcClassifier);
     def dstCf = classifierWithFlavor(dstClassifier);
-    g().E().has('lbl', 'overlaps').
-            order().
-            by('intersection', asc).
-            project('xlbl', 'xclassifier', 'xflavor', 'xcls', 'ylbl', 'yclassifier', 'yflavor', 'ycls', 'intersection').
-            by(inV().values('lbl')).
-            by(inV().values('classifier')).
-            by(inV().values('flavor')).
-            by(inV().values('cls')).
-            by(outV().values('lbl')).
-            by(outV().values('classifier')).
-            by(outV().values('flavor')).
+    g().V().has('lbl',        lbl).
+            has('classifier', srcCf[0]).
+            has('flavor',     srcCf[1]).
+            has('cls',        cls).
+            inE().has('lbl', 'overlaps').
+            as('e').
+            filter(outV().has('lbl',        lbl).
+                          has('classifier', dstCf[0]).
+                          has('flavor',     dstCf[1])).
+            project('dst', 'intersection').
             by(outV().values('cls')).
-            by(values('intersection')).
-            each {v -> 
-                  if (v['xlbl'       ].equals(lbl     ) &&
-                      v['ylbl'       ].equals(lbl     ) &&
-                      v['xcls'       ].equals(cls     ) &&
-                      v['xclassifier'].equals(srcCf[0]) &&
-                      v['yclassifier'].equals(dstCf[0]) &&
-                      v['xflavor'    ].equals(srcCf[1]) &&
-                      v['yflavor'    ].equals(dstCf[1])) {
-                    classification[v['ycls']] = v['intersection'];
-                    }
-                  };
-    classification = classification.sort{-it.value};
-    return classification;
+            by(select('e').values('intersection')).
+            each {row ->
+              def previous = classification[row['dst']];
+              if (previous == null || row['intersection'] > previous) {
+                classification[row['dst']] = row['intersection'];
+                }
+              };
+    return classification.sort{-it.value};
     }
     
   /** Export all <em/>OCol</em>

--- a/src/groovy/testReclassification.groovy
+++ b/src/groovy/testReclassification.groovy
@@ -1,0 +1,56 @@
+import com.Lomikel.Januser.DirectGremlinClient;
+import com.astrolabsoftware.FinkBrowser.Januser.FinkGremlinRecipiesG;
+
+client = new DirectGremlinClient('157.136.253.253', 24444);
+try {
+  gr = new FinkGremlinRecipiesG(client);
+  String oid = 'ZTF19aadouqo';
+  String src = 'FEATURES=2025/13-50';
+  String dst = 'FINK';
+  assert gr.classification(oid, dst).isEmpty() : 'The regression object must remain unclassified in the destination schema';
+
+  long t0 = System.nanoTime();
+  def result = gr.reclassification(oid, src, dst, 10, true);
+  double elapsedMs = (System.nanoTime() - t0) / 1_000_000.0;
+
+  def expected = [
+    'SN candidate'           : 0.9391499883613128,
+    'Microlensing candidate' : 0.0543305219188342,
+    'Solar System candidate' : 0.0028279876786143888,
+    'Early SN Ia candidate'  : 0.0021789859272380507,
+    'Solar System MPC'       : 0.0011782841373792355,
+    'Kilonova candidate'     : 3.3423197662139193E-4
+  ];
+  assert result*.class == expected.keySet().toList() : "Unexpected class ranking: ${result}";
+  result.each { row ->
+    assert row.classifier == 'FINK';
+    assert row.flavor == '';
+    assert Math.abs(row.weight - expected[row.class]) < 1.0E-12 : "Unexpected weight for ${row.class}: ${row.weight}";
+  }
+
+  def singleClass = gr.reclassify('FC-40', 'OCol', src, dst);
+  assert singleClass == ['SN candidate':3.560797004004411,
+                         'Microlensing candidate':0.7439011501426769] : "Standalone reclassify changed: ${singleClass}";
+  assert gr.reclassify(null, 'OCol', src, dst).isEmpty();
+  assert gr.reclassify('FC-40', null, src, dst).isEmpty();
+  assert gr.reclassify('FC-40', 'OCol', null, dst).isEmpty();
+  assert gr.reclassify('FC-40', 'OCol', src, null).isEmpty();
+  def limited = gr.reclassification(oid, src, dst, 2, false);
+  assert limited == result.take(2) : "nmax did not retain the two strongest classes: ${limited}";
+  assert gr.lastQuality() == 0.0 : 'check=false must reset quality';
+  assert gr.reclassification('missing-object-id', src, dst, 10, true).isEmpty();
+  assert gr.lastQuality() == 0.0 : 'A missing object must not retain an earlier quality';
+
+  String classifiedOid = 'ZTF17aackceb';
+  assert !gr.classification(classifiedOid, dst).isEmpty() : 'The quality-check object must be classified in the destination schema';
+  gr.reclassification(classifiedOid, src, dst, 10, true);
+  assert gr.lastQuality() > 0.0 : 'A destination-classified object should produce a quality score';
+  def repeated = gr.reclassification(oid, src, dst, 10, true);
+  assert repeated == result : 'Reclassification changed between identical calls';
+  assert gr.lastQuality() == 0.0 : 'Unavailable quality must not leak from a previous reclassification';
+
+  println "RECLASSIFICATION_REGRESSION_OK MS=${elapsedMs}";
+}
+finally {
+  client.close();
+}


### PR DESCRIPTION
## Summary

- replace per-source-class scans of every `overlaps` edge with one bulk traversal from the relevant source `OCol` vertices
- fetch only correlations to the requested destination classifier and aggregate the weighted target evidence locally
- optimize standalone `reclassify(...)` with the same selective traversal while preserving its existing public signature
- preserve duplicate-edge semantics by retaining the maximum intersection for each source/destination class pair
- reset `lastQuality()` when destination-schema quality cannot be evaluated, avoiding stale quality from a previous call
- add a live ZTF regression covering schema translation for an object that has no recorded FINK classification

## ZTF benchmark

Exact query:

```groovy
gr.reclassification("ZTF19aadouqo", "FEATURES=2025/13-50", "FINK", 10, true)
```

- before: `31,662.379 ms`
- conservative final recorded run: `5,147.554 ms`
- speedup: `6.15x`
- runtime reduction: `83.74%`
- repeated optimized runs: approximately `1.48-5.15 s`
- source classification, empty destination classification, and complete ranked result: identical before/after

Traversal profiling found 32,272 total overlap edges but only 36 relevant correlations for the object's ten source classes. The old implementation transferred and filtered all overlap edges once per source class; the new implementation retrieves the relevant correlations in one traversal.

Standalone `reclassify('FC-40', ...)` improved from `2,717.695 ms` to `357.911 ms` with identical output.

## Verification

- [x] `ant clean exe`
- [x] `src/groovy/testReclassification.groovy` against the live IJCLab ZTF graph
- [x] unclassified destination-schema translation returns the expected six normalized FINK classes
- [x] destination-classified quality calculation and stale-quality reset
- [x] `check=false`, `nmax=2`, missing object, null public-helper arguments, duplicate-safe aggregation
- [x] standalone `reclassify(...)` result matches baseline
- [x] existing `testObjectNeighborhood.groovy`
- [x] supplied `/home/agent/Lomikel/ant/test.groovy`
- [x] `git diff --cached --check`
