### PR TITLE
[verified] fix: provide a single SLF4J binding

### DIFF
--- a/ant/build.xml
+++ b/ant/build.xml
@@ -346,6 +346,8 @@
 			<zipfileset includes="**/*" src="${janusgraph_dir}/lib/javaparser-core-3.25.0.jar"/>
       <zipfileset includes="**/*" src="${janusgraph_dir}/lib/log4j-core-2.20.0.jar"/>
       <zipfileset includes="**/*" src="${janusgraph_dir}/lib/log4j-api-2.20.0.jar"/>
+      <!-- Single shared SLF4J 1.7 binding for all launcher combinations. -->
+      <zipfileset includes="**/*" src="${janusgraph_dir}/lib/log4j-slf4j-impl-2.20.0.jar"/>
       <zipfileset includes="**/*" src="${janusgraph_dir}/lib/httpasyncclient-4.1.5.jar"/>
       <zipfileset includes="**/*" src="${janusgraph_dir}/lib/httpclient-4.5.14.jar"/>
       <zipfileset includes="**/*" src="${janusgraph_dir}/lib/httpclient-4.5.14.jar"/>
@@ -437,7 +439,6 @@
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/kerby-pkix-1.0.1.jar"/>
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/jackson-jaxrs-1.9.13.jar"/>
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/jetty-security-9.3.24.v20180605.jar"/>
-      <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/slf4j-log4j12-1.7.25.jar"/>
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/jersey-server-1.19.jar"/>
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/asm-5.0.4.jar"/>
       <zipfileset includes="**/*" src="${hadoop_dir}/share/hadoop/common/lib/nimbus-jose-jwt-4.41.1.jar"/>


### PR DESCRIPTION
Route SLF4J 1.7 through the existing Log4j2 backend for every Lomikel launcher and remove the competing Hadoop Log4j 1 binding.