### PR TITLE
Fix SS RA/Dec Elasticsearch plotting script

### DIFF
--- a/src/work/CC/plotES-ss-radec.py
+++ b/src/work/CC/plotES-ss-radec.py
@@ -10,7 +10,7 @@ FIELD = "location"
 
 def get_document(ss_id):
     url = f"{ES_URL}/{INDEX}/_doc/{ss_id}"
-    r = requests.get(url, headers={"-u":"elastic:elastic"})
+    r = requests.get(url, timeout=60)
     r.raise_for_status()
     data = r.json()
     if not data.get("found", False):
@@ -60,13 +60,9 @@ def main():
     if not points:
         raise RuntimeError(f"No points found in field '{FIELD}' for {ss_id}")
     ra_values = [p[0] for p in points]
-
-dec_values = [p[1] for p in points]
-    plt.figure(figsize = (8, 5))
-    pl
-    
-t.scatter(ra_values, dec_values, s = 10
-      )
+    dec_values = [p[1] for p in points]
+    plt.figure(figsize=(8, 5))
+    plt.scatter(ra_values, dec_values, s=10)
     plt.xlabel("ra [deg]")
     plt.ylabel("dec [deg]")
     plt.title(f"ra/dec points for ss object {ss_id}")
@@ -74,25 +70,7 @@ t.scatter(ra_values, dec_values, s = 10
     # Optional astronomical convention: RA increases to the left.
     plt.gca().invert_xaxis()
     plt.tight_layout()
-    #plt.show()
     plt.savefig(f"{ss_id}.png", dpi=300)
 
 if __name__ == "__main__":
     main()
-    
-"""
-curl -X GET 'http://134.158.243.139:24499/ss_radec/_search?pretty=true' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "query": {
-      "script": {
-        "script": {
-          "lang":
-          ainless",
-          "source": "doc[\"location\"].size() > 50
-
-
-}
-          }
-}'cp almalinux@134.158.243.139:/home/almalinux/tmp/21163611875234.png ./
-"""


### PR DESCRIPTION
## Summary

- repair the malformed indentation and split `plt.scatter` call in `plotES-ss-radec.py`
- remove an accidental trailing scratch/curl fragment that made the module invalid Python
- replace the ineffective curl-style `-u` request header on the read-only document GET with a 60-second timeout

## Root cause

The current `master` version cannot be imported or executed because the plotting block is malformed and an unterminated scratch fragment follows `main()`. The `{"-u": "elastic:elastic"}` mapping is also not HTTP Basic authentication; this endpoint is a read-only document lookup and was verified to allow anonymous access.

## Validation

- confirmed `origin/master` fails with `IndentationError` at line 65
- `python3 -m py_compile src/work/CC/plotES*.py`
- mocked `get_document()` contract: correct URL and `timeout=60`, with no invalid authentication header
- live run for SS object `21163611358705234` generated a valid 82,370-byte PNG
- `git diff --check`
