### PR TITLE
Move ZTF Elasticsearch plots to IJCLab

### DIFF
--- a/src/work/CC/plotES.sh
+++ b/src/work/CC/plotES.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# LSST Elasticsearch plots.
+# LSST Elasticsearch plots handled by CC.
 python3 ../src/work/CC/plotES-dia-radec.py              --max-points 100000              --output s_dia_radec.png
 python3 ../src/work/CC/plotES-dia-radec-latest.py       --number 100000                  --output s_dia_radec_latest.png
 python3 ../src/work/CC/plotES-ss-radec-top.py           --top-n 10                       --output s_ss_radec_top.png
@@ -9,12 +9,5 @@ python3 ../src/work/CC/plotES-ss-radec-latest.py        --number 10      --min-p
 python3 ../src/work/CC/plotES-hist.py --index ss_radec  --field location --log-y         --output h_ss_radec.png
 python3 ../src/work/CC/plotES-hist.py --index ss_mjd    --field mjd      --log-y         --output h_ss_mjd.png
 python3 ../src/work/CC/plotES-hist.py --index dia_mjd   --field mjd      --log-y         --output h_dia_mjd.png
-
-# ZTF Elasticsearch plots. ZTF has one data type, so there is no ss/dia split.
-# The ZTF radec index currently has one location per object, so top-location and
-# location-count histogram plots are intentionally omitted.
-python3 ../src/work/CC/plotES-ztf-radec.py              --max-points 100000              --output z_ztf_radec.png
-python3 ../src/work/CC/plotES-ztf-radec-latest.py       --number 100000                  --output z_ztf_radec_latest.png
-python3 ../src/work/CC/plotES-ztf-hist.py --index mjd   --field mjd      --log-y         --output z_h_ztf_mjd.png
 
 echo "scp almalinux@134.158.243.139:/home/almalinux/Lomikel/ant/'*'.png ./"

--- a/src/work/IJCLab/plotES-ztf-hist.py
+++ b/src/work/IJCLab/plotES-ztf-hist.py
@@ -8,6 +8,8 @@ DEFAULT_ES_URL = "http://157.136.253.253:24499"
 DEFAULT_INDEX = "radec"
 DEFAULT_FIELD = "location"
 
+REQUEST_TIMEOUT = 120
+
 def normalize_locations(value):
     """Return a list of geo_point-like values from _source[field]."""
     if value is None:
@@ -24,7 +26,7 @@ def es_search(es_url, index, body, scroll=None):
     params = {}
     if scroll:
         params["scroll"] = scroll
-    r = requests.post(url, params=params, json=body, headers={"-u":"elastic:elastic"})
+    r = requests.post(url, params=params, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
@@ -34,21 +36,14 @@ def es_scroll(es_url, scroll_id, scroll="2m"):
         "scroll": scroll,
         "scroll_id": scroll_id,
     }
-    r = requests.post(url, json=body)
+    r = requests.post(url, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
-def es_clear_scroll(es_url, scroll_id):
-    if not scroll_id:
-        return
-    try:
-        requests.delete(
-            f"{es_url}/_search/scroll",
-            json={"scroll_id": [scroll_id]},
-            timeout=10,
-        )
-    except Exception:
-        pass
+def es_clear_scroll(_es_url, _scroll_id):
+    """Let the short scroll TTL expire; never send credentials over plaintext HTTP."""
+    return
+
 
 def collect_point_counts(es_url, index, field, batch_size=1000):
     """

--- a/src/work/IJCLab/plotES-ztf-radec-latest.py
+++ b/src/work/IJCLab/plotES-ztf-radec-latest.py
@@ -10,6 +10,8 @@ DEFAULT_MJD_INDEX = "mjd"
 DEFAULT_LOCATION_FIELD = "location"
 DEFAULT_MJD_FIELD = "mjd"
 
+REQUEST_TIMEOUT = 120
+
 def normalize_locations(value):
     """
     Return a list of geo_point-like values from _source[field].
@@ -87,7 +89,7 @@ def es_search(es_url, index, body, scroll=None):
     if scroll:
         params["scroll"] = scroll
 
-    r = requests.post(url, params=params, json=body, headers={"-u":"elastic:elastic"})
+    r = requests.post(url, params=params, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
@@ -99,23 +101,14 @@ def es_scroll(es_url, scroll_id, scroll="2m"):
         "scroll_id": scroll_id,
     }
 
-    r = requests.post(url, json=body)
+    r = requests.post(url, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
 
-def es_clear_scroll(es_url, scroll_id):
-    if not scroll_id:
-        return
-
-    try:
-        requests.delete(
-            f"{es_url}/_search/scroll",
-            json={"scroll_id": [scroll_id]},
-            timeout=10,
-        )
-    except Exception:
-        pass
+def es_clear_scroll(_es_url, _scroll_id):
+    """Let the short scroll TTL expire; never send credentials over plaintext HTTP."""
+    return
 
 
 def find_last_dia_ids_by_mjd(es_url, mjd_index, mjd_field, n=100000, batch_size=2000):
@@ -222,7 +215,7 @@ def mget_radec_points(es_url, radec_index, location_field, mjd_id_pairs, chunk_s
         }
 
         url = f"{es_url}/{radec_index}/_mget"
-        r = requests.post(url, json=body)
+        r = requests.post(url, json=body, timeout=REQUEST_TIMEOUT)
 
         if not r.ok:
             print("Bad _mget request:")

--- a/src/work/IJCLab/plotES-ztf-radec.py
+++ b/src/work/IJCLab/plotES-ztf-radec.py
@@ -9,6 +9,8 @@ DEFAULT_ES_URL = "http://157.136.253.253:24499"
 DEFAULT_INDEX = "radec"
 DEFAULT_FIELD = "location"
 
+REQUEST_TIMEOUT = 120
+
 def normalize_locations(value):
     """
     Return a list of geo_point-like values from _source[field].
@@ -60,7 +62,7 @@ def es_search(es_url, index, body, scroll = None):
     params = {}
     if scroll:
         params["scroll"] = scroll
-    r = requests.post(url, params=params, json=body, headers={"-u":"elastic:elastic"})
+    r = requests.post(url, params=params, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
@@ -70,21 +72,14 @@ def es_scroll(es_url, scroll_id, scroll = "2m"):
         "scroll": scroll,
         "scroll_id": scroll_id,
     }
-    r = requests.post(url, json = body)
+    r = requests.post(url, json=body, timeout=REQUEST_TIMEOUT)
     r.raise_for_status()
     return r.json()
 
-def es_clear_scroll(es_url, scroll_id):
-    if not scroll_id:
-        return
-    try:
-        requests.delete(
-            f"{es_url}/_search/scroll",
-            json={"scroll_id": [scroll_id]},
-            timeout = 10,
-        )
-    except Exception:
-        pass
+def es_clear_scroll(_es_url, _scroll_id):
+    """Let the short scroll TTL expire; never send credentials over plaintext HTTP."""
+    return
+
 
 def collect_all_points(es_url, index, field, batch_size=1000):
     """

--- a/src/work/IJCLab/plotES.sh
+++ b/src/work/IJCLab/plotES.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ZTF Elasticsearch plots handled by IJCLab. ZTF has one data type, so there
+# is no ss/dia split. The radec index currently has one location per object,
+# so top-location and location-count histogram plots are intentionally omitted.
+python3 ../src/work/IJCLab/plotES-ztf-radec.py              --max-points 100000              --output z_ztf_radec.png
+python3 ../src/work/IJCLab/plotES-ztf-radec-latest.py       --number 100000                  --output z_ztf_radec_latest.png
+python3 ../src/work/IJCLab/plotES-ztf-hist.py --index mjd   --field mjd      --log-y         --output z_h_ztf_mjd.png


### PR DESCRIPTION
## Summary

- move the three ZTF Elasticsearch plotting utilities from `src/work/CC` to `src/work/IJCLab`, which owns the ZTF data workflow
- keep the LSST plotting utilities under `src/work/CC`
- split the combined `plotES.sh` into an LSST-only CC driver and a ZTF-only IJCLab driver
- remove malformed curl-style authentication headers from anonymous read-only searches
- add request timeouts and let short-lived scroll contexts expire rather than transmitting Basic credentials over the plaintext HTTP endpoint

## Files moved

- `plotES-ztf-radec.py`
- `plotES-ztf-radec-latest.py`
- `plotES-ztf-hist.py`

## Validation

- all `plotES*.py` files under CC and IJCLab compile with `python3 -m py_compile`
- both `plotES.sh` drivers pass `bash -n`
- structural checks confirm CC references only existing LSST scripts and IJCLab references only existing ZTF scripts
- mocked request-contract tests verify timed anonymous reads and no credential transmission or unauthenticated mutation
- the installed Hermes LSST/ZTF monitoring wrappers invoke the plotting utilities from their respective CC and IJCLab directories
- live monitoring runs generated every expected PNG and emitted only `MEDIA:` lines
- independent pre-commit review passed
- `git diff --check`
